### PR TITLE
[feat/EATBOOK-59] 특정 유저가 북마크를 누른 소설 목록 조회하는 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/ktb/eatbookappbackend/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,14 @@
+package com.ktb.eatbookappbackend.domain.bookmark.repository;
+
+import com.ktb.eatbookappbackend.entity.Bookmark;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+    @Query("SELECT b FROM Bookmark b JOIN FETCH b.novel WHERE b.member.id = :memberId ORDER BY b.createdAt DESC")
+    Page<Bookmark> findByMemberIdWithNovel(String memberId, Pageable pageable);
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/authentication/Authenticated.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/authentication/Authenticated.java
@@ -1,0 +1,11 @@
+package com.ktb.eatbookappbackend.domain.global.authentication;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authenticated {
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/authentication/AuthenticationAspect.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/authentication/AuthenticationAspect.java
@@ -1,0 +1,43 @@
+package com.ktb.eatbookappbackend.domain.global.authentication;
+
+import com.ktb.eatbookappbackend.domain.global.message.MessageCode;
+import com.ktb.eatbookappbackend.domain.global.reponse.FailureResponseDTO;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class AuthenticationAspect {
+    private static final ThreadLocal<String> memberIdThreadLocal = new ThreadLocal<>();
+
+    private final String fixedMemberId = "00bc7946-f8ad-4076-805f-8c8346b339a8";
+
+    @Around("@annotation(authenticated)")
+    public Object checkAuthentication(ProceedingJoinPoint joinPoint, Authenticated authenticated) throws Throwable {
+        boolean isAuthenticated = isUserAuthenticated();
+        if (!isAuthenticated) {
+            return ResponseEntity.status(401).body(FailureResponseDTO.of(MessageCode.GlobalErrorMessage.UNAUTHORIZED_ACCESS));
+        }
+
+        memberIdThreadLocal.set(fixedMemberId);
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            memberIdThreadLocal.remove();
+        }
+    }
+
+    private boolean isUserAuthenticated() {
+        // TO DO - 실제 인증 로직 구현
+        return true;
+    }
+
+    public static String getAuthenticatedMemberId() {
+        return memberIdThreadLocal.get();
+    }
+}
+

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/authentication/AuthenticationAspect.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/authentication/AuthenticationAspect.java
@@ -8,6 +8,10 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
+/**
+ * 특정 메서드에 접근하기 전에 사용자가 인증되었는지 확인하는 Aspect입니다.
+ * 또한 인증된 멤버의 ID를 가져오는 방법을 제공합니다.
+ */
 @Aspect
 @Component
 public class AuthenticationAspect {
@@ -15,6 +19,9 @@ public class AuthenticationAspect {
 
     private final String fixedMemberId = "00bc7946-f8ad-4076-805f-8c8346b339a8";
 
+    /**
+     * 사용자가 인증되었는지 확인하고 인증된 멤버의 ID를 스레드 로컬 변수에 저장합니다.
+     */
     @Around("@annotation(authenticated)")
     public Object checkAuthentication(ProceedingJoinPoint joinPoint, Authenticated authenticated) throws Throwable {
         boolean isAuthenticated = isUserAuthenticated();
@@ -31,11 +38,17 @@ public class AuthenticationAspect {
         }
     }
 
+    /**
+     * 사용자가 인증되었는지 확인합니다.
+     */
     private boolean isUserAuthenticated() {
         // TO DO - 실제 인증 로직 구현
         return true;
     }
 
+    /**
+     * 스레드 로컬 변수에서 인증된 멤버의 ID를 가져옵니다.
+     */
     public static String getAuthenticatedMemberId() {
         return memberIdThreadLocal.get();
     }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/dto/PaginationInfoDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/dto/PaginationInfoDTO.java
@@ -1,0 +1,8 @@
+package com.ktb.eatbookappbackend.domain.global.dto;
+
+public record PaginationInfoDTO(
+        int currentPage,
+        int pageSize,
+        int totalItems,
+        int totalPages
+) {}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/dto/PaginationWithDataDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/dto/PaginationWithDataDTO.java
@@ -1,0 +1,13 @@
+package com.ktb.eatbookappbackend.domain.global.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record PaginationWithDataDTO<T>(
+        PaginationInfoDTO pagination,
+        Map<String, List<T>> data
+) {
+    public static <T> PaginationWithDataDTO<T> of(PaginationInfoDTO pagination, String key, List<T> items) {
+        return new PaginationWithDataDTO<>(pagination, Map.of(key, items));
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/exception/DomainException.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/exception/DomainException.java
@@ -1,0 +1,15 @@
+package com.ktb.eatbookappbackend.domain.global.exception;
+
+import com.ktb.eatbookappbackend.domain.global.message.MessageCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class DomainException extends RuntimeException {
+    private final HttpStatus status;
+
+    public DomainException(final MessageCode errorCode) {
+        super(errorCode.getMessage());
+        this.status = errorCode.getStatus();
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/message/MessageCode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/message/MessageCode.java
@@ -1,0 +1,23 @@
+package com.ktb.eatbookappbackend.domain.global.message;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+public interface MessageCode {
+    HttpStatus getStatus();
+    String getMessage();
+
+    @Getter
+    enum GlobalErrorMessage implements MessageCode {
+        INVALID_PARAMETER("잘못된 파라미터입니다.", HttpStatus.BAD_REQUEST),
+        UNAUTHORIZED_ACCESS("인증되지 않은 요청입니다.", HttpStatus.UNAUTHORIZED);
+
+        private final String message;
+        private final HttpStatus status;
+
+        GlobalErrorMessage(final String message, final HttpStatus status) {
+            this.message = message;
+            this.status = status;
+        }
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/reponse/FailureResponseDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/reponse/FailureResponseDTO.java
@@ -1,10 +1,16 @@
 package com.ktb.eatbookappbackend.domain.global.reponse;
 
+import com.ktb.eatbookappbackend.domain.global.message.MessageCode;
+
 public record FailureResponseDTO (
         int statusCode,
         String message,
         String subStatus
 ) {
+    public static FailureResponseDTO of(MessageCode errorMessage) {
+        return new FailureResponseDTO(errorMessage.getStatus().value(), errorMessage.getMessage(), null);
+    }
+
     public static FailureResponseDTO of(int statusCode, String message) {
         return new FailureResponseDTO(statusCode, message, null);
     }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/reponse/FailureResponseDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/reponse/FailureResponseDTO.java
@@ -1,0 +1,15 @@
+package com.ktb.eatbookappbackend.domain.global.reponse;
+
+public record FailureResponseDTO (
+        int statusCode,
+        String message,
+        String subStatus
+) {
+    public static FailureResponseDTO of(int statusCode, String message) {
+        return new FailureResponseDTO(statusCode, message, null);
+    }
+
+    public static FailureResponseDTO of(int statusCode, String message, String subStatus) {
+        return new FailureResponseDTO(statusCode, message, subStatus);
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/reponse/SuccessResponseDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/reponse/SuccessResponseDTO.java
@@ -1,0 +1,15 @@
+package com.ktb.eatbookappbackend.domain.global.reponse;
+
+public record SuccessResponseDTO<T> (
+        int statusCode,
+        String message,
+        T data
+) {
+    public static <T> SuccessResponseDTO<T> of(int statusCode, String message) {
+        return new SuccessResponseDTO<>(statusCode, message, null);
+    }
+
+    public static <T> SuccessResponseDTO<T> of(int statusCode, String message, T data) {
+        return new SuccessResponseDTO<>(statusCode, message, data);
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/global/reponse/SuccessResponseDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/global/reponse/SuccessResponseDTO.java
@@ -1,10 +1,20 @@
 package com.ktb.eatbookappbackend.domain.global.reponse;
 
+import com.ktb.eatbookappbackend.domain.global.message.MessageCode;
+
 public record SuccessResponseDTO<T> (
         int statusCode,
         String message,
         T data
 ) {
+    public static <T> SuccessResponseDTO<T> of(MessageCode successMessageCode) {
+        return new SuccessResponseDTO<>(successMessageCode.getStatus().value(), successMessageCode.getMessage(), null);
+    }
+
+    public static <T> SuccessResponseDTO<T> of(MessageCode successMessageCode, T data) {
+        return new SuccessResponseDTO<>(successMessageCode.getStatus().value(), successMessageCode.getMessage(), data);
+    }
+
     public static <T> SuccessResponseDTO<T> of(int statusCode, String message) {
         return new SuccessResponseDTO<>(statusCode, message, null);
     }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/member/controller/MemberController.java
@@ -23,6 +23,18 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    /**
+     * 특정 회원이 북마크한 소설 목록을 페이지네이션하여 조회합니다.
+     * 이 메소드는 보안되어 있으며 인증이 필요합니다.
+     *
+     * @param page 조회할 결과의 페이지 번호. 양의 정수여야 합니다.
+     * @param size 페이지당 항목 수. 양의 정수여야 합니다.
+     * @return 다음 중 하나를 포함하는 ResponseEntity:
+     *         - 북마크된 소설 목록이 있는 경우, 페이지네이션된 목록을 포함한 SuccessResponseDTO
+     *         - 북마크가 없는 경우, NO_RESULTS_FOUND 메시지를 포함한 SuccessResponseDTO
+     *         - page 또는 size 매개변수가 유효하지 않은 경우, FailureResponseDTO
+     * @throws RuntimeException 인증 실패 시
+     */
     @Authenticated
     @GetMapping("/bookmarks")
     public ResponseEntity<?> getMemberBookmarkedNovels(@RequestParam final int page, @RequestParam final int size) {

--- a/src/main/java/com/ktb/eatbookappbackend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/member/controller/MemberController.java
@@ -1,0 +1,48 @@
+package com.ktb.eatbookappbackend.domain.member.controller;
+
+import com.ktb.eatbookappbackend.domain.global.authentication.Authenticated;
+import com.ktb.eatbookappbackend.domain.global.authentication.AuthenticationAspect;
+import com.ktb.eatbookappbackend.domain.global.dto.PaginationWithDataDTO;
+import com.ktb.eatbookappbackend.domain.global.message.MessageCode;
+import com.ktb.eatbookappbackend.domain.global.reponse.FailureResponseDTO;
+import com.ktb.eatbookappbackend.domain.global.reponse.SuccessResponseDTO;
+import com.ktb.eatbookappbackend.domain.member.dto.MemberBookmarkedNovelDTO;
+import com.ktb.eatbookappbackend.domain.member.message.MemberSuccessCode;
+import com.ktb.eatbookappbackend.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Authenticated
+    @GetMapping("/bookmarks")
+    public ResponseEntity<?> getMemberBookmarkedNovels(@RequestParam final int page, @RequestParam final int size) {
+        String memberId = AuthenticationAspect.getAuthenticatedMemberId();
+        if (page < 1 || size < 1) {
+            return ResponseEntity.badRequest()
+                    .body(FailureResponseDTO.of(MessageCode.GlobalErrorMessage.INVALID_PARAMETER));
+        }
+
+        PaginationWithDataDTO<MemberBookmarkedNovelDTO> bookmarkedNovels = memberService.getMemberBookmarkedNovels(memberId, page, size);
+
+        if (page - 1 > bookmarkedNovels.pagination().totalPages()) {
+            return ResponseEntity.badRequest()
+                    .body(FailureResponseDTO.of(MessageCode.GlobalErrorMessage.INVALID_PARAMETER));
+        }
+
+        if (bookmarkedNovels.data().get("novels").isEmpty()) {
+            return ResponseEntity.ok(SuccessResponseDTO.of(MemberSuccessCode.NO_RESULTS_FOUND, bookmarkedNovels));
+        }
+
+        return ResponseEntity.ok(SuccessResponseDTO.of(MemberSuccessCode.BOOKMARKS_RETRIEVED, bookmarkedNovels));
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/member/dto/MemberBookmarkedNovelDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/member/dto/MemberBookmarkedNovelDTO.java
@@ -1,0 +1,23 @@
+package com.ktb.eatbookappbackend.domain.member.dto;
+
+import com.ktb.eatbookappbackend.entity.Novel;
+
+public record MemberBookmarkedNovelDTO(
+        String id,
+        String title,
+        String coverImageUrl,
+        int viewCount,
+        int favoriteCount,
+        boolean isFavorited
+) {
+    public static MemberBookmarkedNovelDTO of(Novel novel) {
+        return new MemberBookmarkedNovelDTO(
+                novel.getId(),
+                novel.getTitle(),
+                novel.getCoverImageUrl(),
+                novel.getViewCount(),
+                0, // TO DO - 실제 좋아요 수 반환
+                false // TO DO - 실제 좋아요 여부 반환
+        );
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/member/message/MemberErrorCode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/member/message/MemberErrorCode.java
@@ -1,0 +1,19 @@
+package com.ktb.eatbookappbackend.domain.member.message;
+
+import com.ktb.eatbookappbackend.domain.global.message.MessageCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MemberErrorCode implements MessageCode {
+    PAPER_NOT_FOUND("요청하신 페이퍼를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    PAPER_CREATION_FAILED("페이지 생성에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus status;
+
+    MemberErrorCode(final String message, final HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/member/message/MemberSuccessCode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/member/message/MemberSuccessCode.java
@@ -1,0 +1,19 @@
+package com.ktb.eatbookappbackend.domain.member.message;
+
+import com.ktb.eatbookappbackend.domain.global.message.MessageCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MemberSuccessCode implements MessageCode {
+    BOOKMARKS_RETRIEVED("성공적으로 북마크를 누른 소설 목록을 조회했습니다.", HttpStatus.OK),
+    NO_RESULTS_FOUND("조회 결과가 없습니다.", HttpStatus.OK);
+
+    private final String message;
+    private final HttpStatus status;
+
+    MemberSuccessCode(final String message, final HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/member/service/MemberService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/member/service/MemberService.java
@@ -19,6 +19,14 @@ public class MemberService {
 
     private final BookmarkRepository bookmarkRepository;
 
+    /**
+     * 특정 멤버가 북마크한 소설 목록을 페이지로 나누어 반환합니다.
+     *
+     * @param memberId 멤버의 고유 식별자.
+     * @param page 검색할 페이지 번호.
+     * @param size 페이지 당 항목 수.
+     * @return {@link PaginationWithDataDTO} 페이지네이션 정보와 북마크된 소설 목록을 담고 있는 객체.
+     */
     public PaginationWithDataDTO<MemberBookmarkedNovelDTO> getMemberBookmarkedNovels(String memberId, int page, int size) {
         PageRequest pageRequest = PageRequest.of(page - 1, size);
         Page<Bookmark> bookmarkPage = bookmarkRepository.findByMemberIdWithNovel(memberId, pageRequest);

--- a/src/main/java/com/ktb/eatbookappbackend/domain/member/service/MemberService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/member/service/MemberService.java
@@ -32,8 +32,8 @@ public class MemberService {
         Page<Bookmark> bookmarkPage = bookmarkRepository.findByMemberIdWithNovel(memberId, pageRequest);
 
         PaginationInfoDTO paginationInfo = new PaginationInfoDTO(
-                bookmarkPage.getNumber() + 1,
-                bookmarkPage.getSize(),
+                page,
+                size,
                 (int) bookmarkPage.getTotalElements(),
                 bookmarkPage.getTotalPages()
         );

--- a/src/main/java/com/ktb/eatbookappbackend/domain/member/service/MemberService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/member/service/MemberService.java
@@ -1,0 +1,39 @@
+package com.ktb.eatbookappbackend.domain.member.service;
+
+import com.ktb.eatbookappbackend.domain.global.dto.PaginationWithDataDTO;
+import com.ktb.eatbookappbackend.domain.bookmark.repository.BookmarkRepository;
+import com.ktb.eatbookappbackend.domain.global.dto.PaginationInfoDTO;
+import com.ktb.eatbookappbackend.domain.member.dto.MemberBookmarkedNovelDTO;
+import com.ktb.eatbookappbackend.entity.Bookmark;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final BookmarkRepository bookmarkRepository;
+
+    public PaginationWithDataDTO<MemberBookmarkedNovelDTO> getMemberBookmarkedNovels(String memberId, int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page - 1, size);
+        Page<Bookmark> bookmarkPage = bookmarkRepository.findByMemberIdWithNovel(memberId, pageRequest);
+
+        PaginationInfoDTO paginationInfo = new PaginationInfoDTO(
+                bookmarkPage.getNumber() + 1,
+                bookmarkPage.getSize(),
+                (int) bookmarkPage.getTotalElements(),
+                bookmarkPage.getTotalPages()
+        );
+
+        List<MemberBookmarkedNovelDTO> bookmarks = bookmarkPage.getContent().stream()
+                .map(bookmark -> MemberBookmarkedNovelDTO.of(bookmark.getNovel()))
+                .collect(Collectors.toList());
+
+        return PaginationWithDataDTO.of(paginationInfo, "novels", bookmarks);
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/entity/Author.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/Author.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import org.antlr.v4.runtime.misc.NotNull;
 
 import java.util.Objects;
-import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,9 +16,9 @@ import java.util.UUID;
 public class Author extends SoftDeletableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "VARCHAR(36)")
-    private UUID id;
+    @Column(length = 36)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
 
     @NotNull
     @Column(nullable = false)
@@ -27,7 +26,7 @@ public class Author extends SoftDeletableEntity {
 
     @Builder
     public Author(String name) {
-        this.id = id;
+        this.name = name;
     }
 
     @Override

--- a/src/main/java/com/ktb/eatbookappbackend/entity/Bookmark.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/Bookmark.java
@@ -21,25 +21,34 @@ import java.util.Objects;
 public class Bookmark {
 
     @Id
-    @NotNull
-    @ManyToOne
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    @JoinColumn(name = "novel_id", nullable = false)
-    private Novel novel;
+    @Column(name = "novel_id", length = 36)
+    private String novelId;
 
     @Id
-    @ManyToOne
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @Column(name = "member_id", length = 36)
+    private String memberId;
 
-    @CreatedDate
+    @Column(nullable = false)
     @NotNull
-    @Column(nullable = false, updatable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    @NotNull
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Novel novel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    @NotNull
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member member;
+
     @Builder
-    public Bookmark(Novel novel, Member member) {
+    public Bookmark(String novelId, String memberId, Novel novel, Member member) {
+        this.novelId = novelId;
+        this.memberId = memberId;
         this.novel = novel;
         this.member = member;
     }

--- a/src/main/java/com/ktb/eatbookappbackend/entity/Category.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/Category.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import org.antlr.v4.runtime.misc.NotNull;
 
 import java.util.Objects;
-import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,9 +16,9 @@ import java.util.UUID;
 public class Category extends SoftDeletableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "VARCHAR(36)")
-    private UUID id;
+    @Column(length = 36)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
 
     @NotNull
     @Column(nullable = false, length = 50)

--- a/src/main/java/com/ktb/eatbookappbackend/entity/Episode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/Episode.java
@@ -2,7 +2,6 @@ package com.ktb.eatbookappbackend.entity;
 
 import com.ktb.eatbookappbackend.entity.base.SoftDeletableEntity;
 import com.ktb.eatbookappbackend.entity.constant.EpisodeReleaseStatus;
-import com.ktb.eatbookappbackend.entity.constant.Role;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,7 +11,6 @@ import org.antlr.v4.runtime.misc.NotNull;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
-import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,9 +18,9 @@ import java.util.UUID;
 public class Episode extends SoftDeletableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "VARCHAR(36)")
-    private UUID id;
+    @Column(length = 36)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
 
     @NotNull
     @Column(nullable = false)

--- a/src/main/java/com/ktb/eatbookappbackend/entity/FileMetadata.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/FileMetadata.java
@@ -2,7 +2,6 @@ package com.ktb.eatbookappbackend.entity;
 
 
 import com.ktb.eatbookappbackend.entity.base.BaseEntity;
-import com.ktb.eatbookappbackend.entity.constant.EpisodeReleaseStatus;
 import com.ktb.eatbookappbackend.entity.constant.FileType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -14,7 +13,6 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.Objects;
-import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,9 +20,9 @@ import java.util.UUID;
 public class FileMetadata extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "VARCHAR(36)")
-    private UUID id;
+    @Column(length = 36)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
 
     @NotNull
     @Column(nullable = false)

--- a/src/main/java/com/ktb/eatbookappbackend/entity/IdClass/BookmarkId.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/IdClass/BookmarkId.java
@@ -13,13 +13,13 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BookmarkId {
 
-    private Novel novel;
-    private Member member;
+    private String novelId;
+    private String memberId;
 
     @Builder
-    public BookmarkId(Novel novel, Member member) {
-        this.novel = novel;
-        this.member = member;
+    public BookmarkId(String novelId, String memberId) {
+        this.novelId = novelId;
+        this.memberId = memberId;
     }
 
     @Override
@@ -27,11 +27,11 @@ public class BookmarkId {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         BookmarkId that = (BookmarkId) o;
-        return Objects.equals(novel, that.novel) && Objects.equals(member, that.member);
+        return Objects.equals(novelId, that.novelId) && Objects.equals(memberId, that.memberId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(novel, member);
+        return Objects.hash(novelId, memberId);
     }
 }

--- a/src/main/java/com/ktb/eatbookappbackend/entity/Member.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/Member.java
@@ -21,9 +21,9 @@ import java.util.UUID;
 public class Member extends SoftDeletableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "VARCHAR(36)")
-    private UUID id;
+    @Column(length = 36)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
 
     @NotNull
     @Column(nullable = false, length = 100)
@@ -42,7 +42,6 @@ public class Member extends SoftDeletableEntity {
     private String passwordHash;
 
     private String email;
-
 
     @Builder
     public Member(String nickname, String profileImageUrl, String email) {

--- a/src/main/java/com/ktb/eatbookappbackend/entity/Novel.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/Novel.java
@@ -20,9 +20,9 @@ import java.util.UUID;
 public class Novel extends SoftDeletableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "VARCHAR(36)")
-    private UUID id;
+    @Column(length = 36)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
 
     @NotNull
     @Column(nullable = false)

--- a/src/main/java/com/ktb/eatbookappbackend/entity/SearchLog.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/SearchLog.java
@@ -10,7 +10,6 @@ import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
-import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,9 +17,9 @@ import java.util.UUID;
 public class SearchLog {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "VARCHAR(36)")
-    private UUID id;
+    @Column(length = 36)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
 
     @NotNull
     @CreatedDate

--- a/src/test/java/com/ktb/eatbookappbackend/member/fixture/MemberFixture.java
+++ b/src/test/java/com/ktb/eatbookappbackend/member/fixture/MemberFixture.java
@@ -1,0 +1,51 @@
+package com.ktb.eatbookappbackend.member.fixture;
+
+import com.ktb.eatbookappbackend.entity.Bookmark;
+import com.ktb.eatbookappbackend.entity.Member;
+import com.ktb.eatbookappbackend.entity.Novel;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.UUID;
+
+public class MemberFixture {
+
+    public static final int PAGE = 1;
+    public static final int SIZE = 10;
+    public static final int TOTAL_ITEMS = 1;
+    public static final int TOTAL_PAGES = 1;
+
+    public static final int EMPTY_TOTAL_ITEMS = 0;
+    public static final int EMPTY_TOTAL_PAGES = 1;
+
+    public static Member createMember() {
+        Member member = Member.builder()
+                .nickname("nickname")
+                .profileImageUrl("profile")
+                .email("email")
+                .build();
+        String memberId = UUID.randomUUID().toString();
+        ReflectionTestUtils.setField(member, "id", memberId);
+        return member;
+    }
+
+    public static Novel createNovel() {
+        Novel novel = Novel.builder()
+                .title("Novel Title")
+                .coverImageUrl("coverImageUrl")
+                .summary("Novel Summary")
+                .isCompleted(true)
+                .build();
+        String novelID = UUID.randomUUID().toString();
+        ReflectionTestUtils.setField(novel, "id", novelID);
+        return novel;
+    }
+
+    public static Bookmark createBookmark(Novel novel, Member member) {
+        return Bookmark.builder()
+                .novelId(novel.getId())
+                .memberId(member.getId())
+                .novel(novel)
+                .member(member)
+                .build();
+    }
+}

--- a/src/test/java/com/ktb/eatbookappbackend/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ktb/eatbookappbackend/member/service/MemberServiceTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
 @ExtendWith(MockitoExtension.class)
 public class MemberServiceTest {
 

--- a/src/test/java/com/ktb/eatbookappbackend/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ktb/eatbookappbackend/member/service/MemberServiceTest.java
@@ -1,0 +1,123 @@
+package com.ktb.eatbookappbackend.member.service;
+
+import com.ktb.eatbookappbackend.domain.bookmark.repository.BookmarkRepository;
+import com.ktb.eatbookappbackend.domain.global.dto.PaginationInfoDTO;
+import com.ktb.eatbookappbackend.domain.global.dto.PaginationWithDataDTO;
+import com.ktb.eatbookappbackend.domain.member.dto.MemberBookmarkedNovelDTO;
+import com.ktb.eatbookappbackend.domain.member.service.MemberService;
+import com.ktb.eatbookappbackend.entity.Bookmark;
+import com.ktb.eatbookappbackend.entity.Member;
+import com.ktb.eatbookappbackend.entity.Novel;
+import com.ktb.eatbookappbackend.member.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    private Member member;
+    private Novel novel;
+    private Bookmark bookmark;
+    private Page<Bookmark> bookmarkPage;
+
+    @BeforeEach
+    public void setUp() {
+        member = MemberFixture.createMember();
+        novel = MemberFixture.createNovel();
+        bookmark = MemberFixture.createBookmark(novel, member);
+    }
+
+    @Test
+    public void getMemberBookmarkedNovels_ValidInput_ReturnsExpectedBookmarks() {
+        // Given
+        String memberId = member.getId();
+        int page = MemberFixture.PAGE;
+        int size = MemberFixture.SIZE;
+        int totalItems = MemberFixture.TOTAL_ITEMS;
+        int totalPages = MemberFixture.TOTAL_PAGES;
+
+        MemberBookmarkedNovelDTO expectedBookmarkDTO = new MemberBookmarkedNovelDTO(
+                novel.getId(),
+                novel.getTitle(),
+                novel.getCoverImageUrl(),
+                novel.getViewCount(),
+                0,
+                false
+        );
+        PaginationInfoDTO expectedPagination = new PaginationInfoDTO(page, size, totalItems, totalPages);
+        PaginationWithDataDTO<MemberBookmarkedNovelDTO> expectedResult = PaginationWithDataDTO.of(expectedPagination, "novels", List.of(expectedBookmarkDTO));
+
+        // When
+        bookmarkPage = new PageImpl<>(Collections.singletonList(bookmark));
+        when(bookmarkRepository.findByMemberIdWithNovel(any(), any(PageRequest.class))).thenReturn(bookmarkPage);
+        PaginationWithDataDTO<MemberBookmarkedNovelDTO> result = memberService.getMemberBookmarkedNovels(memberId, page, size);
+
+        // Then
+        assertNotNull(result);
+        assertAll(
+                () -> assertEquals(expectedResult.pagination().currentPage(), result.pagination().currentPage()),
+                () -> assertEquals(expectedResult.pagination().pageSize(), result.pagination().pageSize()),
+                () -> assertEquals(expectedResult.pagination().totalItems(), result.pagination().totalItems()),
+                () -> assertEquals(expectedResult.pagination().totalPages(), result.pagination().totalPages())
+        );
+
+        List<MemberBookmarkedNovelDTO> bookmarks = result.data().get("novels");
+        assertNotNull(bookmarks);
+        assertEquals(totalItems, bookmarks.size());
+
+        MemberBookmarkedNovelDTO bookmarkDTO = bookmarks.get(0);
+        assertEquals(novel.getId(), bookmarkDTO.id());
+        assertEquals(novel.getTitle(), bookmarkDTO.title());
+    }
+    
+
+    @Test
+    public void getMemberBookmarkedNovels_NoBookmarks_ReturnsEmptyResult() {
+        // Given
+        String memberId = member.getId();
+        int page = MemberFixture.PAGE;
+        int size = MemberFixture.SIZE;
+        int totalItems = MemberFixture.EMPTY_TOTAL_ITEMS;
+        int totalPages = MemberFixture.EMPTY_TOTAL_PAGES;
+
+        PaginationInfoDTO expectedPagination = new PaginationInfoDTO(page, size, totalItems, totalPages);
+        PaginationWithDataDTO<MemberBookmarkedNovelDTO> expectedResult = PaginationWithDataDTO.of(expectedPagination, "novels", Collections.emptyList());
+
+        // When
+        when(bookmarkRepository.findByMemberIdWithNovel(any(), any(PageRequest.class))).thenReturn(new PageImpl<>(Collections.emptyList()));
+        PaginationWithDataDTO<MemberBookmarkedNovelDTO> result = memberService.getMemberBookmarkedNovels(memberId, page, size);
+
+        // Then
+        assertNotNull(result);
+        assertAll(
+                () -> assertEquals(expectedResult.pagination().currentPage(), result.pagination().currentPage()),
+                () -> assertEquals(expectedResult.pagination().pageSize(), result.pagination().pageSize()),
+                () -> assertEquals(expectedResult.pagination().totalItems(), result.pagination().totalItems()),
+                () -> assertEquals(expectedResult.pagination().totalPages(), result.pagination().totalPages())
+        );
+        assertEquals(Collections.emptyList(), result.data().get("novels"));
+    }
+}

--- a/src/test/java/com/ktb/eatbookappbackend/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ktb/eatbookappbackend/member/service/MemberServiceTest.java
@@ -50,7 +50,7 @@ public class MemberServiceTest {
     }
 
     @Test
-    public void getMemberBookmarkedNovels_ValidInput_ReturnsExpectedBookmarks() {
+    public void should_ReturnBookmarks_When_ValidInput() {
         // Given
         String memberId = member.getId();
         int page = MemberFixture.PAGE;
@@ -94,7 +94,7 @@ public class MemberServiceTest {
     
 
     @Test
-    public void getMemberBookmarkedNovels_NoBookmarks_ReturnsEmptyResult() {
+    public void should_ReturnEmptyResult_When_NoBookmarks() {
         // Given
         String memberId = member.getId();
         int page = MemberFixture.PAGE;


### PR DESCRIPTION
## 설명
<!-- PR에서 해결하려는 문제나 기능을 간단히 설명합니다. -->
- 이 PR은 특정 유저가 북마크를 누른 소설 목록 조회하는 페이지네이션 API를 추가합니다.
- 성공, 실패에 대해 Global한 Response DTO를 정의합니다.

## 포함된 변경 사항
<!-- 코드에서 어떤 변화가 이루어졌는지 요약합니다. 주요 변경 사항을 나열하세요. -->
- Entity의 id type이 UUID인 경우, JPA가 제대로 match 안되는 이슈가 발생하여 tpye을 String으로 변경했습니다.
- Member Controller, Service, Unit Test를 구현했습니다.
- JPQL을 이용하여 특정 회원에 대한 북마크와 관련된 소설을 조회하는 쿼리 구현
- 유저 인증 권한을 확인하는 Aspect를 임시로 구현했습니다.

## 추가 참고 사항
<!-- 리뷰어가 알아야 할 추가적인 정보나 참고해야 할 내용이 있다면 여기에 작성하세요. 예를 들어, 관련된 이슈 번호나 외부 링크 등을 포함할 수 있습니다. -->

- 유저 인증 권한을 확인하는 Aspect에서 인증 로직에 대해 현재는 전부 통과하고, 고정된 id 반환하도록 구현했습니다. 추후에 로그인 기능을 도입하면서 token을 입력받아 권한을 확인하는 로직을 구현할 예정입니다.
- 또한 페이지네이션 시, 풀스캔을 방지하기 위해 index를 생성했습니다. 관련한 문서는 [노션](https://www.notion.so/cjm-0611/JPA-12d5b188f94a80e88bb6d9a307a385e8?pvs=4)을 확인해주시면 감사하겠습니다.
