### PR TITLE
[feat/EATBOOK-104] 검색 기록 생성 API 구현

### DIFF
--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/controller/SearchLogController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/controller/SearchLogController.java
@@ -22,6 +22,14 @@ public class SearchLogController {
 
     private final SearchLogService searchService;
 
+    /**
+     * 이 메소드는 검색 로그 생성 요청을 처리합니다. {@link SearchLogRequest} 객체를 받아 검색어를 포함하고, {@link SearchLogService}를 사용하여 해당 검색어에 해당하는
+     * {@link SearchLogDTO} 객체를 생성합니다. 그런 다음, {@link ResponseEntity}를 반환하며, 성공 코드와 생성된 {@link SearchLogResponse}를 포함하는
+     * {@link SuccessResponseDTO}를 담습니다.
+     *
+     * @param searchLogRequest 검색어를 포함하는 요청 객체.
+     * @return {@link SearchLogResponse}를 포함하는 성공 코드가 있는 {@link SuccessResponseDTO}를 포함하는 {@link ResponseEntity}.
+     */
     @PostMapping()
     public ResponseEntity<SuccessResponseDTO> createSearchLog(@RequestBody SearchLogRequest searchLogRequest) {
         SearchLogDTO searchLog = searchService.createSearchLog(searchLogRequest.term());

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/controller/SearchLogController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/controller/SearchLogController.java
@@ -1,0 +1,30 @@
+package com.ktb.eatbookappbackend.domain.search.controller;
+
+import com.ktb.eatbookappbackend.domain.global.reponse.SuccessResponseDTO;
+import com.ktb.eatbookappbackend.domain.search.dto.SearchLogDTO;
+import com.ktb.eatbookappbackend.domain.search.dto.SearchLogRequest;
+import com.ktb.eatbookappbackend.domain.search.dto.SearchLogResponse;
+import com.ktb.eatbookappbackend.domain.search.message.SearchLogSuccessCode;
+import com.ktb.eatbookappbackend.domain.search.service.SearchLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/search/log")
+public class SearchLogController {
+
+    private final SearchLogService searchService;
+
+    @PostMapping()
+    public ResponseEntity<SuccessResponseDTO> createSearchLog(@RequestBody SearchLogRequest searchLogRequest) {
+        SearchLogDTO searchLog = searchService.createSearchLog(searchLogRequest.term());
+        return ResponseEntity.ok(SuccessResponseDTO.of(SearchLogSuccessCode.SEARCH_LOG_CREATED, SearchLogResponse.of(searchLog)));
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/dto/SearchLogDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/dto/SearchLogDTO.java
@@ -1,0 +1,11 @@
+package com.ktb.eatbookappbackend.domain.search.dto;
+
+public record SearchLogDTO(
+    String id,
+    String term
+) {
+
+    public static SearchLogDTO of(String id, String term) {
+        return new SearchLogDTO(id, term);
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/dto/SearchLogRequest.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/dto/SearchLogRequest.java
@@ -1,0 +1,7 @@
+package com.ktb.eatbookappbackend.domain.search.dto;
+
+public record SearchLogRequest(
+    String term
+) {
+
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/dto/SearchLogResponse.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/dto/SearchLogResponse.java
@@ -1,0 +1,10 @@
+package com.ktb.eatbookappbackend.domain.search.dto;
+
+public record SearchLogResponse(
+    SearchLogDTO searchLog
+) {
+
+    public static SearchLogResponse of(SearchLogDTO searchLog) {
+        return new SearchLogResponse(searchLog);
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/exception/SearchLogException.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/exception/SearchLogException.java
@@ -1,0 +1,16 @@
+package com.ktb.eatbookappbackend.domain.search.exception;
+
+import com.ktb.eatbookappbackend.domain.global.exception.DomainException;
+import com.ktb.eatbookappbackend.domain.search.message.SearchLogErrorCode;
+import lombok.Getter;
+
+@Getter
+public class SearchLogException extends DomainException {
+
+    private final SearchLogErrorCode errorCode;
+
+    public SearchLogException(SearchLogErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/exception/SearchLogExceptionHandler.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/exception/SearchLogExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.ktb.eatbookappbackend.domain.search.exception;
+
+import com.ktb.eatbookappbackend.domain.global.reponse.FailureResponseDTO;
+import com.ktb.eatbookappbackend.domain.search.message.SearchLogErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class SearchLogExceptionHandler {
+
+    @ExceptionHandler(SearchLogException.class)
+    public ResponseEntity<?> handleNovelException(SearchLogException e) {
+        SearchLogErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus())
+            .body(FailureResponseDTO.of(errorCode));
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/message/SearchLogErrorCode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/message/SearchLogErrorCode.java
@@ -1,0 +1,16 @@
+package com.ktb.eatbookappbackend.domain.search.message;
+
+import com.ktb.eatbookappbackend.domain.global.message.MessageCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SearchLogErrorCode implements MessageCode {
+    TERM_REQUIRED("검색어는 필수 입력 항목입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/message/SearchLogSuccessCode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/message/SearchLogSuccessCode.java
@@ -1,0 +1,17 @@
+package com.ktb.eatbookappbackend.domain.search.message;
+
+import com.ktb.eatbookappbackend.domain.global.message.MessageCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SearchLogSuccessCode implements MessageCode {
+    SEARCH_LOG_CREATED("성공적으로 검색 기록을 생성했습니다.", HttpStatus.CREATED);
+
+    private final String message;
+    private final HttpStatus status;
+}
+

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/repository/SearchLogRepository.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/repository/SearchLogRepository.java
@@ -1,0 +1,8 @@
+package com.ktb.eatbookappbackend.domain.search.repository;
+
+import com.ktb.eatbookappbackend.entity.SearchLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SearchLogRepository extends JpaRepository<SearchLog, Long> {
+
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/service/SearchLogService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/service/SearchLogService.java
@@ -15,16 +15,23 @@ public class SearchLogService {
 
     private final SearchLogRepository searchLogRepository;
 
+    /**
+     * 데이터베이스에 새로운 검색 로그 항목을 생성합니다.
+     *
+     * @param term 사용자가 입력한 검색어. 이 값은 null이거나 빈 문자열일 수 없습니다.
+     * @return {@link SearchLogDTO} 객체로, 새로 생성된 검색 로그 항목의 ID와 검색어를 포함합니다.
+     * @throws SearchLogException 검색어가 null이거나 빈 문자열인 경우 발생합니다.
+     */
     @Transactional
     public SearchLogDTO createSearchLog(String term) {
         if (term == null || term.trim().isEmpty()) {
             throw new SearchLogException(SearchLogErrorCode.TERM_REQUIRED);
         }
-
+    
         SearchLog searchLog = SearchLog.builder()
             .term(term)
             .build();
-
+    
         searchLogRepository.save(searchLog);
         return SearchLogDTO.of(searchLog.getId(), term);
     }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/search/service/SearchLogService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/search/service/SearchLogService.java
@@ -1,0 +1,31 @@
+package com.ktb.eatbookappbackend.domain.search.service;
+
+import com.ktb.eatbookappbackend.domain.search.dto.SearchLogDTO;
+import com.ktb.eatbookappbackend.domain.search.exception.SearchLogException;
+import com.ktb.eatbookappbackend.domain.search.message.SearchLogErrorCode;
+import com.ktb.eatbookappbackend.domain.search.repository.SearchLogRepository;
+import com.ktb.eatbookappbackend.entity.SearchLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class SearchLogService {
+
+    private final SearchLogRepository searchLogRepository;
+
+    @Transactional
+    public SearchLogDTO createSearchLog(String term) {
+        if (term == null || term.trim().isEmpty()) {
+            throw new SearchLogException(SearchLogErrorCode.TERM_REQUIRED);
+        }
+
+        SearchLog searchLog = SearchLog.builder()
+            .term(term)
+            .build();
+
+        searchLogRepository.save(searchLog);
+        return SearchLogDTO.of(searchLog.getId(), term);
+    }
+}

--- a/src/test/java/com/ktb/eatbookappbackend/search/fixture/SearchLogFixture.java
+++ b/src/test/java/com/ktb/eatbookappbackend/search/fixture/SearchLogFixture.java
@@ -1,0 +1,17 @@
+package com.ktb.eatbookappbackend.search.fixture;
+
+import com.ktb.eatbookappbackend.entity.SearchLog;
+import java.util.UUID;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class SearchLogFixture {
+
+    public static SearchLog createSearchLog(String term) {
+        SearchLog searchLog = SearchLog.builder()
+            .term(term)
+            .build();
+        String searchLogId = UUID.randomUUID().toString();
+        ReflectionTestUtils.setField(searchLog, "id", searchLogId);
+        return searchLog;
+    }
+}

--- a/src/test/java/com/ktb/eatbookappbackend/search/service/SearchLogServiceTest.java
+++ b/src/test/java/com/ktb/eatbookappbackend/search/service/SearchLogServiceTest.java
@@ -1,0 +1,65 @@
+package com.ktb.eatbookappbackend.search.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ktb.eatbookappbackend.domain.search.dto.SearchLogDTO;
+import com.ktb.eatbookappbackend.domain.search.exception.SearchLogException;
+import com.ktb.eatbookappbackend.domain.search.message.SearchLogErrorCode;
+import com.ktb.eatbookappbackend.domain.search.repository.SearchLogRepository;
+import com.ktb.eatbookappbackend.domain.search.service.SearchLogService;
+import com.ktb.eatbookappbackend.entity.SearchLog;
+import com.ktb.eatbookappbackend.search.fixture.SearchLogFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class SearchLogServiceTest {
+
+    @InjectMocks
+    private SearchLogService searchLogService;
+
+    @Mock
+    private SearchLogRepository searchLogRepository;
+
+    @Test
+    void should_CreateSearchLog_When_TermIsValid() {
+        // Given
+        String term = "검색어";
+        SearchLog expectedSearchLog = SearchLogFixture.createSearchLog(term);
+        when(searchLogRepository.save(any(SearchLog.class))).thenReturn(expectedSearchLog);
+
+        // When
+        SearchLogDTO result = searchLogService.createSearchLog(term);
+
+        // Then
+        verify(searchLogRepository).save(any(SearchLog.class));
+        assertEquals(expectedSearchLog.getTerm(), result.term());
+    }
+
+    @Test
+    void should_ThrowException_When_TermIsNull() {
+        // Given
+        String term = null;
+
+        // When & Then
+        SearchLogException exception = assertThrows(SearchLogException.class, () -> searchLogService.createSearchLog(term));
+        assertEquals(SearchLogErrorCode.TERM_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    void should_ThrowException_When_TermIsEmpty() {
+        // Given
+        String term = "   ";
+
+        // When & Then
+        SearchLogException exception = assertThrows(SearchLogException.class, () -> searchLogService.createSearchLog(term));
+        assertEquals(SearchLogErrorCode.TERM_REQUIRED, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
## 설명
<!-- PR에서 해결하려는 문제나 기능을 간단히 설명합니다. -->

- 사용자에게 term(검색어)를 입력받아 검색 기록을 생성하는 API를 구현합니다.
- 검색어가 null이거나 공백으로 이루어진 경우 에러를 발생시킵니다.
- 검색어를 생성하는 것은 Member가 아니여도 가능합니다. (인증 없이 접근 가능합니다.)

## 포함된 변경 사항
<!-- 코드에서 어떤 변화가 이루어졌는지 요약합니다. 주요 변경 사항을 나열하세요. -->

- Repository 생성
- DTO 타입 생성
- Exception과 ExceptionHandler 생성
- 컨트롤러, 서비스, 테스트 코드 작성

## 테스트 방법
<!-- 변경된 부분을 테스트한 방법을 설명합니다. -->

SearchLogServiceTest에서 아래의 경우에 대해 테스트를 진행합니다.
1. 정상적인 검색어가 입력되었을 때 정상적으로 검색 기록 생성
2. 검색어가 null인 경우 에러 발생
3. 검색어가 공백으로 이루어진 경우 에러 발생

## 추가 참고 사항
<!-- 리뷰어가 알아야 할 추가적인 정보나 참고해야 할 내용이 있다면 여기에 작성하세요. 예를 들어, 관련된 이슈 번호나 외부 링크 등을 포함할 수 있습니다. -->

- 검색 기록은 사용자에 대한 정보를 저장하지 않습니다.
- 또한 검색 기록은 삭제될 일이 없습니다.
- 자세한 것은 디스코드의 ERD 채널 확인 부탁드립니다.

