### PR TITLE
[feat/EATBOOK-32] 토큰 유효성 검증 API 구현

### DIFF
--- a/src/main/java/com/ktb/eatbookappbackend/oauth/controller/AuthController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/oauth/controller/AuthController.java
@@ -29,6 +29,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -137,5 +138,18 @@ public class AuthController {
         String refreshToken = request.getHeader(REFRESH_TOKEN.getValue());
         tokenService.deleteRefreshToken(refreshToken);
         return SuccessResponse.toResponseEntity(AuthSuccessCode.DELETE_MEMBER_COMPLETED);
+    }
+
+    /**
+     * 토큰 유효성 확인 API
+     * <p>
+     * 이 API는 JWT 필터를 통해 토큰이 유효한 경우 OK 상태를 반환합니다.
+     *
+     * @return {@link ResponseEntity}로, 성공적으로 토큰이 유효한 경우 OK 상태와 메시지를 반환합니다.
+     */
+    @Secured(Role.MEMBER_VALUE)
+    @GetMapping("/validate-token")
+    public ResponseEntity<SuccessResponseDTO> validateToken() {
+        return SuccessResponse.toResponseEntity(AuthSuccessCode.TOKEN_VALID);
     }
 }

--- a/src/main/java/com/ktb/eatbookappbackend/oauth/message/AuthSuccessCode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/oauth/message/AuthSuccessCode.java
@@ -12,7 +12,8 @@ public enum AuthSuccessCode implements MessageCode {
     LOGIN_COMPLETED("성공적으로 로그인했습니다.", HttpStatus.OK),
     LOGOUT_COMPLETED("성공적으로 로그아웃했습니다.", HttpStatus.OK),
     SIGN_UP_COMPLETED("성공적으로 회원가입했습니다.", HttpStatus.CREATED),
-    DELETE_MEMBER_COMPLETED("성공적으로 회원탈퇴했습니다.", HttpStatus.OK);
+    DELETE_MEMBER_COMPLETED("성공적으로 회원탈퇴했습니다.", HttpStatus.OK),
+    TOKEN_VALID("토큰이 유효합니다.", HttpStatus.OK);
 
     private final String message;
     private final HttpStatus status;


### PR DESCRIPTION
## 설명
<!-- PR에서 해결하려는 문제나 기능을 간단히 설명합니다. -->
- 사용자에게 AccessToken과 RefreshToken을 넘겨받아, 유효한 토큰인지 확인하는 API를 구현합니다.
- 사용자가 앱을 강제로 종료하고 재실행한 경우, 로컬에 남아있는 토큰이 유효한지 검사하는 로직을 구현하기 위해 필요합니다.

## 포함된 변경 사항
<!-- 코드에서 어떤 변화가 이루어졌는지 요약합니다. 주요 변경 사항을 나열하세요. -->

- 토큰의 유효성 검사 및 토큰 재발급은 이미 필터에 구현되어 있으므로, 유효성 결과를 응답하는 간단한 API를 추가했습니다.

## 추가 참고 사항
<!-- 리뷰어가 알아야 할 추가적인 정보나 참고해야 할 내용이 있다면 여기에 작성하세요. 예를 들어, 관련된 이슈 번호나 외부 링크 등을 포함할 수 있습니다. -->

- 해당 API의 필요성에 대해서는 [Jira 티켓](https://ktb-eatbook.atlassian.net/jira/software/projects/EATBOOK/boards/2?assignee=712020%3A543c9971-f3aa-4bf4-9ea4-68c8e59e58a3&selectedIssue=EATBOOK-205)에 자세히 적어놨습니다.
