### PR TITLE
[feat/EATBOOK-178] 에피소드 조회 댓글, 생성, 삭제 API 구현

### DIFF
--- a/src/main/java/com/ktb/eatbookappbackend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,13 @@
 package com.ktb.eatbookappbackend.domain.comment.repository;
 
 import com.ktb.eatbookappbackend.entity.Comment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, String>, CommentRepositoryCustom {
+
+    @Query("SELECT c FROM Comment c WHERE c.episode.id = :episodeId AND c.deletedAt IS NULL ORDER BY c.createdAt DESC")
+    List<Comment> findCommentsByEpisodeId(@Param("episodeId") String episodeId);
 }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/comment/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.ktb.eatbookappbackend.domain.comment.repository;
 
 import com.ktb.eatbookappbackend.entity.Comment;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,4 +11,6 @@ public interface CommentRepository extends JpaRepository<Comment, String>, Comme
 
     @Query("SELECT c FROM Comment c WHERE c.episode.id = :episodeId AND c.deletedAt IS NULL ORDER BY c.createdAt DESC")
     List<Comment> findCommentsByEpisodeId(@Param("episodeId") String episodeId);
+
+    Optional<Comment> findByIdAndDeletedAtIsNull(String id);
 }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/episodes/{episodeId}/comments")
+@RequestMapping("/api/episodes")
 @RequiredArgsConstructor
 public class EpisodeCommentController {
 
@@ -33,7 +33,7 @@ public class EpisodeCommentController {
      * @return ResponseEntity로, SuccessResponseDTO를 포함하는 응답. 이 응답에는 상태 코드와 에피소드에 대한 댓글 데이터를 포함하는 EpisodeCommentsDTO 객체가 있습니다.
      */
     @Secured(Role.MEMBER_VALUE)
-    @GetMapping
+    @GetMapping("/{episodeId}/comments")
     public ResponseEntity<SuccessResponseDTO> getComments(@PathVariable("episodeId") String episodeId) {
         EpisodeCommentsDTO episodeCommentsDTO = episodeCommentService.getCommentsByEpisodeId(episodeId);
         return SuccessResponse.toResponseEntity(EpisodeSuccessCode.COMMENTS_RETRIEVED, episodeCommentsDTO);
@@ -43,12 +43,12 @@ public class EpisodeCommentController {
      * 특정 에피소드에 대한 새로운 댓글을 생성합니다.
      *
      * @param episodeId 에피소드의 고유 식별자.
-     * @param memberId 댓글을 생성하는 멤버의 고유 식별자.
-     * @param request 댓글 내용을 포함하는 요청 객체.
+     * @param memberId  댓글을 생성하는 멤버의 고유 식별자.
+     * @param request   댓글 내용을 포함하는 요청 객체.
      * @return ResponseEntity로, SuccessResponseDTO를 포함하는 응답. 이 응답에는 성공 상태 코드와 생성된 댓글 데이터를 CommentDTO 객체로 포함합니다.
      */
     @Secured(Role.MEMBER_VALUE)
-    @PostMapping
+    @PostMapping("/{episodeId}/comments")
     public ResponseEntity<SuccessResponseDTO> createComment(
         @PathVariable("episodeId") String episodeId,
         @AuthenticationPrincipal String memberId,
@@ -66,7 +66,7 @@ public class EpisodeCommentController {
      * @return ResponseEntity로, SuccessResponseDTO를 포함하는 응답. 이 응답에는 성공 여부를 나타내는 상태 코드가 포함됩니다.
      */
     @Secured(Role.MEMBER_VALUE)
-    @DeleteMapping("/{commentId}")
+    @DeleteMapping("/{episodeId}/comments/{commentId}")
     public ResponseEntity<SuccessResponseDTO> deleteComment(
         @PathVariable("episodeId") String episodeId,
         @PathVariable("commentId") String commentId

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
@@ -1,0 +1,27 @@
+package com.ktb.eatbookappbackend.domain.episode.controller;
+
+import com.ktb.eatbookappbackend.domain.episode.dto.EpisodeCommentsDTO;
+import com.ktb.eatbookappbackend.domain.episode.message.EpisodeCommentSuccessCode;
+import com.ktb.eatbookappbackend.domain.episode.service.EpisodeCommentService;
+import com.ktb.eatbookappbackend.global.reponse.SuccessResponse;
+import com.ktb.eatbookappbackend.global.reponse.SuccessResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/episodes/{episodeId}/comments")
+@RequiredArgsConstructor
+public class EpisodeCommentController {
+
+    private final EpisodeCommentService episodeCommentService;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDTO> getComments(@PathVariable("episodeId") String episodeId) {
+        EpisodeCommentsDTO episodeCommentsDTO = episodeCommentService.getCommentsByEpisodeId(episodeId);
+        return SuccessResponse.toResponseEntity(EpisodeCommentSuccessCode.COMMENTS_RETRIEVED, episodeCommentsDTO);
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
@@ -1,14 +1,21 @@
 package com.ktb.eatbookappbackend.domain.episode.controller;
 
+import com.ktb.eatbookappbackend.domain.episode.dto.CommentDTO;
 import com.ktb.eatbookappbackend.domain.episode.dto.EpisodeCommentsDTO;
-import com.ktb.eatbookappbackend.domain.episode.message.EpisodeCommentSuccessCode;
+import com.ktb.eatbookappbackend.domain.episode.message.EpisodeSuccessCode;
 import com.ktb.eatbookappbackend.domain.episode.service.EpisodeCommentService;
+import com.ktb.eatbookappbackend.entity.constant.Role;
 import com.ktb.eatbookappbackend.global.reponse.SuccessResponse;
 import com.ktb.eatbookappbackend.global.reponse.SuccessResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +29,27 @@ public class EpisodeCommentController {
     @GetMapping
     public ResponseEntity<SuccessResponseDTO> getComments(@PathVariable("episodeId") String episodeId) {
         EpisodeCommentsDTO episodeCommentsDTO = episodeCommentService.getCommentsByEpisodeId(episodeId);
-        return SuccessResponse.toResponseEntity(EpisodeCommentSuccessCode.COMMENTS_RETRIEVED, episodeCommentsDTO);
+        return SuccessResponse.toResponseEntity(EpisodeSuccessCode.COMMENTS_RETRIEVED, episodeCommentsDTO);
+    }
+
+    @Secured(Role.MEMBER_VALUE)
+    @PostMapping
+    public ResponseEntity<SuccessResponseDTO> createComment(
+        @PathVariable("episodeId") String episodeId,
+        @AuthenticationPrincipal String memberId,
+        @RequestBody EpisodeCommentRequestDTO request
+    ) {
+        CommentDTO comment = episodeCommentService.createComment(episodeId, memberId, request);
+        return SuccessResponse.toResponseEntity(EpisodeSuccessCode.COMMENT_CREATED, comment);
+    }
+
+    @Secured(Role.MEMBER_VALUE)
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<SuccessResponseDTO> deleteComment(
+        @PathVariable("episodeId") String episodeId,
+        @PathVariable("commentId") String commentId
+    ) {
+        episodeCommentService.deleteComment(commentId);
+        return SuccessResponse.toResponseEntity(EpisodeSuccessCode.COMMENT_DELETED);
     }
 }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
@@ -26,12 +26,27 @@ public class EpisodeCommentController {
 
     private final EpisodeCommentService episodeCommentService;
 
+    /**
+     * 특정 에피소드에 대한 댓글을 가져옵니다.
+     *
+     * @param episodeId 에피소드의 고유 식별자.
+     * @return ResponseEntity로, SuccessResponseDTO를 포함하는 응답. 이 응답에는 상태 코드와 에피소드에 대한 댓글 데이터를 포함하는 EpisodeCommentsDTO 객체가 있습니다.
+     */
+    @Secured(Role.MEMBER_VALUE)
     @GetMapping
     public ResponseEntity<SuccessResponseDTO> getComments(@PathVariable("episodeId") String episodeId) {
         EpisodeCommentsDTO episodeCommentsDTO = episodeCommentService.getCommentsByEpisodeId(episodeId);
         return SuccessResponse.toResponseEntity(EpisodeSuccessCode.COMMENTS_RETRIEVED, episodeCommentsDTO);
     }
 
+    /**
+     * 특정 에피소드에 대한 새로운 댓글을 생성합니다.
+     *
+     * @param episodeId 에피소드의 고유 식별자.
+     * @param memberId 댓글을 생성하는 멤버의 고유 식별자.
+     * @param request 댓글 내용을 포함하는 요청 객체.
+     * @return ResponseEntity로, SuccessResponseDTO를 포함하는 응답. 이 응답에는 성공 상태 코드와 생성된 댓글 데이터를 CommentDTO 객체로 포함합니다.
+     */
     @Secured(Role.MEMBER_VALUE)
     @PostMapping
     public ResponseEntity<SuccessResponseDTO> createComment(
@@ -43,6 +58,13 @@ public class EpisodeCommentController {
         return SuccessResponse.toResponseEntity(EpisodeSuccessCode.COMMENT_CREATED, comment);
     }
 
+    /**
+     * 특정 에피소드에 대한 댓글을 삭제합니다.
+     *
+     * @param episodeId 에피소드의 고유 식별자.
+     * @param commentId 삭제할 댓글의 고유 식별자.
+     * @return ResponseEntity로, SuccessResponseDTO를 포함하는 응답. 이 응답에는 성공 여부를 나타내는 상태 코드가 포함됩니다.
+     */
     @Secured(Role.MEMBER_VALUE)
     @DeleteMapping("/{commentId}")
     public ResponseEntity<SuccessResponseDTO> deleteComment(

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentRequestDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentRequestDTO.java
@@ -1,0 +1,7 @@
+package com.ktb.eatbookappbackend.domain.episode.controller;
+
+public record EpisodeCommentRequestDTO(
+    String content
+) {
+
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/dto/CommentDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/dto/CommentDTO.java
@@ -1,0 +1,14 @@
+package com.ktb.eatbookappbackend.domain.episode.dto;
+
+import java.time.LocalDateTime;
+
+public record CommentDTO(
+    String id,
+    String content,
+    LocalDateTime createdAt
+) {
+
+    public static CommentDTO of(String id, String content, LocalDateTime createdAt) {
+        return new CommentDTO(id, content, createdAt);
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/dto/EpisodeCommentsDTO.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/dto/EpisodeCommentsDTO.java
@@ -1,0 +1,12 @@
+package com.ktb.eatbookappbackend.domain.episode.dto;
+
+import java.util.List;
+
+public record EpisodeCommentsDTO(
+    List<CommentDTO> comments
+) {
+
+    public static EpisodeCommentsDTO of(List<CommentDTO> comments) {
+        return new EpisodeCommentsDTO(comments);
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/exception/EpisodeException.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/exception/EpisodeException.java
@@ -1,0 +1,16 @@
+package com.ktb.eatbookappbackend.domain.episode.exception;
+
+import com.ktb.eatbookappbackend.domain.episode.message.EpisodeErrorCode;
+import com.ktb.eatbookappbackend.global.exception.DomainException;
+import lombok.Getter;
+
+@Getter
+public class EpisodeException extends DomainException {
+
+    private final EpisodeErrorCode errorCode;
+
+    public EpisodeException(EpisodeErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/exception/EpisodeExceptionHandler.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/exception/EpisodeExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.ktb.eatbookappbackend.domain.episode.exception;
+
+import com.ktb.eatbookappbackend.domain.episode.message.EpisodeErrorCode;
+import com.ktb.eatbookappbackend.global.reponse.FailureResponseDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class EpisodeExceptionHandler {
+
+    @ExceptionHandler(EpisodeException.class)
+    public ResponseEntity<FailureResponseDTO> handleNovelException(EpisodeException e) {
+        EpisodeErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus())
+            .body(FailureResponseDTO.of(errorCode));
+    }
+}
+

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/message/EpisodeCommentSuccessCode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/message/EpisodeCommentSuccessCode.java
@@ -1,0 +1,16 @@
+package com.ktb.eatbookappbackend.domain.episode.message;
+
+import com.ktb.eatbookappbackend.global.message.MessageCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum EpisodeCommentSuccessCode implements MessageCode {
+    COMMENTS_RETRIEVED("에피소드의 댓글 리스트를 성공적으로 조회했습니다.", HttpStatus.OK);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/message/EpisodeErrorCode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/message/EpisodeErrorCode.java
@@ -1,0 +1,21 @@
+package com.ktb.eatbookappbackend.domain.episode.message;
+
+import com.ktb.eatbookappbackend.global.message.MessageCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum EpisodeErrorCode implements MessageCode {
+
+    EPISODE_NOT_FOUND("에피소드를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COMMENT_NOT_FOUND("삭제할 댓글을 찾지 못했습니다.", HttpStatus.NOT_FOUND),
+    COMMENT_DELETE_PERMISSION_DENIED("해당 유저는 댓글을 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST);
+
+    private final String message;
+    private final HttpStatus status;
+}
+
+

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/message/EpisodeSuccessCode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/message/EpisodeSuccessCode.java
@@ -8,8 +8,10 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public enum EpisodeCommentSuccessCode implements MessageCode {
-    COMMENTS_RETRIEVED("에피소드의 댓글 리스트를 성공적으로 조회했습니다.", HttpStatus.OK);
+public enum EpisodeSuccessCode implements MessageCode {
+    COMMENTS_RETRIEVED("에피소드의 댓글 리스트를 성공적으로 조회했습니다.", HttpStatus.OK),
+    COMMENT_CREATED("성공적으로 댓글을 생성했습니다.", HttpStatus.CREATED),
+    COMMENT_DELETED("성공적으로 댓글을 삭제했습니다.", HttpStatus.OK);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/repository/EpisodeRepository.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/repository/EpisodeRepository.java
@@ -1,8 +1,10 @@
 package com.ktb.eatbookappbackend.domain.episode.repository;
 
 import com.ktb.eatbookappbackend.entity.Episode;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EpisodeRepository extends JpaRepository<Episode, String> {
 
+    Optional<Episode> findById(String id);
 }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/service/EpisodeCommentService.java
@@ -1,0 +1,32 @@
+package com.ktb.eatbookappbackend.domain.episode.service;
+
+import com.ktb.eatbookappbackend.domain.comment.repository.CommentRepository;
+import com.ktb.eatbookappbackend.domain.episode.dto.CommentDTO;
+import com.ktb.eatbookappbackend.domain.episode.dto.EpisodeCommentsDTO;
+import com.ktb.eatbookappbackend.entity.Comment;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class EpisodeCommentService {
+
+    private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public EpisodeCommentsDTO getCommentsByEpisodeId(String episodeId) {
+        List<Comment> comments = commentRepository.findCommentsByEpisodeId(episodeId);
+
+        List<CommentDTO> commentDTOs = comments.stream()
+            .map(comment -> CommentDTO.of(
+                comment.getId(),
+                comment.getContent(),
+                comment.getCreatedAt()
+            ))
+            .toList();
+
+        return EpisodeCommentsDTO.of(commentDTOs);
+    }
+}

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/service/EpisodeCommentService.java
@@ -24,6 +24,13 @@ public class EpisodeCommentService {
     private final EpisodeRepository episodeRepository;
     private final MemberService memberService;
 
+    /**
+     * 특정 에피소드에 대한 모든 댓글을 검색합니다.
+     *
+     * @param episodeId 에피소드의 고유 식별자.
+     * @return EpisodeCommentsDTO, 지정된 에피소드에 대한 댓글 목록을 포함합니다.
+     * @throws EpisodeException 지정된 에피소드가 존재하지 않는 경우.
+     */
     @Transactional(readOnly = true)
     public EpisodeCommentsDTO getCommentsByEpisodeId(String episodeId) {
         List<Comment> comments = commentRepository.findCommentsByEpisodeId(episodeId);
@@ -39,6 +46,15 @@ public class EpisodeCommentService {
         return EpisodeCommentsDTO.of(commentDTOs);
     }
 
+    /**
+     * 특정 에피소드에 대한 새로운 댓글을 생성합니다.
+     *
+     * @param episodeId 에피소드의 고유 식별자.
+     * @param memberId 댓글을 작성하는 멤버의 고유 식별자.
+     * @param request 댓글 내용을 포함하는 요청 객체.
+     * @return CommentDTO, 새로 생성된 댓글을 나타내는 DTO.
+     * @throws EpisodeException 지정된 에피소드가 존재하지 않는 경우.
+     */
     @Transactional
     public CommentDTO createComment(String episodeId, String memberId, EpisodeCommentRequestDTO request) {
         Episode episode = episodeRepository.findById(episodeId).orElseThrow(() -> new EpisodeException(EpisodeErrorCode.EPISODE_NOT_FOUND));
@@ -57,6 +73,12 @@ public class EpisodeCommentService {
         );
     }
 
+    /**
+     * 데이터베이스에서 특정 댓글을 삭제합니다.
+     *
+     * @param commentId 삭제할 댓글의 고유 식별자.
+     * @throws EpisodeException 지정된 댓글이 존재하지 않는 경우.
+     */
     @Transactional
     public void deleteComment(String commentId) {
         Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/service/EpisodeCommentService.java
@@ -1,9 +1,16 @@
 package com.ktb.eatbookappbackend.domain.episode.service;
 
 import com.ktb.eatbookappbackend.domain.comment.repository.CommentRepository;
+import com.ktb.eatbookappbackend.domain.episode.controller.EpisodeCommentRequestDTO;
 import com.ktb.eatbookappbackend.domain.episode.dto.CommentDTO;
 import com.ktb.eatbookappbackend.domain.episode.dto.EpisodeCommentsDTO;
+import com.ktb.eatbookappbackend.domain.episode.exception.EpisodeException;
+import com.ktb.eatbookappbackend.domain.episode.message.EpisodeErrorCode;
+import com.ktb.eatbookappbackend.domain.episode.repository.EpisodeRepository;
+import com.ktb.eatbookappbackend.domain.member.service.MemberService;
 import com.ktb.eatbookappbackend.entity.Comment;
+import com.ktb.eatbookappbackend.entity.Episode;
+import com.ktb.eatbookappbackend.entity.Member;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class EpisodeCommentService {
 
     private final CommentRepository commentRepository;
+    private final EpisodeRepository episodeRepository;
+    private final MemberService memberService;
 
     @Transactional(readOnly = true)
     public EpisodeCommentsDTO getCommentsByEpisodeId(String episodeId) {
@@ -28,5 +37,30 @@ public class EpisodeCommentService {
             .toList();
 
         return EpisodeCommentsDTO.of(commentDTOs);
+    }
+
+    @Transactional
+    public CommentDTO createComment(String episodeId, String memberId, EpisodeCommentRequestDTO request) {
+        Episode episode = episodeRepository.findById(episodeId).orElseThrow(() -> new EpisodeException(EpisodeErrorCode.EPISODE_NOT_FOUND));
+        Member member = memberService.findById(memberId);
+        Comment comment = Comment.builder()
+            .content(request.content())
+            .episode(episode)
+            .member(member)
+            .build();
+        commentRepository.save(comment);
+
+        return CommentDTO.of(
+            comment.getId(),
+            comment.getContent(),
+            comment.getCreatedAt()
+        );
+    }
+
+    @Transactional
+    public void deleteComment(String commentId) {
+        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+            .orElseThrow(() -> new EpisodeException(EpisodeErrorCode.COMMENT_NOT_FOUND));
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/ktb/eatbookappbackend/entity/Comment.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/Comment.java
@@ -1,18 +1,23 @@
 package com.ktb.eatbookappbackend.entity;
 
-import com.ktb.eatbookappbackend.entity.base.BaseEntity;
-import jakarta.persistence.*;
+import com.ktb.eatbookappbackend.entity.base.SoftDeletableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.antlr.v4.runtime.misc.NotNull;
 
-import java.util.Objects;
-
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity
-public class Comment extends BaseEntity {
+public class Comment extends SoftDeletableEntity {
 
     @Id
     @Column(length = 36)
@@ -40,8 +45,12 @@ public class Comment extends BaseEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Comment comment = (Comment) o;
         return Objects.equals(id, comment.id);
     }

--- a/src/test/java/com/ktb/eatbookappbackend/comment/fixture/CommentFixture.java
+++ b/src/test/java/com/ktb/eatbookappbackend/comment/fixture/CommentFixture.java
@@ -1,0 +1,23 @@
+package com.ktb.eatbookappbackend.comment.fixture;
+
+import com.ktb.eatbookappbackend.entity.Comment;
+import com.ktb.eatbookappbackend.entity.Episode;
+import com.ktb.eatbookappbackend.entity.Member;
+import java.util.UUID;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class CommentFixture {
+
+    private static final String CONTENT = "테스트용 댓글 내용";
+
+    public static Comment createComment(Episode episode, Member member) {
+        Comment comment = Comment.builder()
+            .content(CONTENT)
+            .episode(episode)
+            .member(member)
+            .build();
+        String commentID = UUID.randomUUID().toString();
+        ReflectionTestUtils.setField(comment, "id", commentID);
+        return comment;
+    }
+}

--- a/src/test/java/com/ktb/eatbookappbackend/episode/service/EpisodeCommentServiceTest.java
+++ b/src/test/java/com/ktb/eatbookappbackend/episode/service/EpisodeCommentServiceTest.java
@@ -1,0 +1,130 @@
+package com.ktb.eatbookappbackend.domain.episode.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ktb.eatbookappbackend.comment.fixture.CommentFixture;
+import com.ktb.eatbookappbackend.domain.comment.repository.CommentRepository;
+import com.ktb.eatbookappbackend.domain.episode.controller.EpisodeCommentRequestDTO;
+import com.ktb.eatbookappbackend.domain.episode.dto.CommentDTO;
+import com.ktb.eatbookappbackend.domain.episode.dto.EpisodeCommentsDTO;
+import com.ktb.eatbookappbackend.domain.episode.exception.EpisodeException;
+import com.ktb.eatbookappbackend.domain.episode.message.EpisodeErrorCode;
+import com.ktb.eatbookappbackend.domain.episode.repository.EpisodeRepository;
+import com.ktb.eatbookappbackend.domain.member.service.MemberService;
+import com.ktb.eatbookappbackend.entity.Comment;
+import com.ktb.eatbookappbackend.entity.Episode;
+import com.ktb.eatbookappbackend.entity.Member;
+import com.ktb.eatbookappbackend.episode.fixture.EpisodeFixture;
+import com.ktb.eatbookappbackend.member.fixture.MemberFixture;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EpisodeCommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private EpisodeRepository episodeRepository;
+
+    @Mock
+    private MemberService memberService;
+
+    @InjectMocks
+    private EpisodeCommentService episodeCommentService;
+
+    private Episode episode;
+    private Member member;
+
+    @BeforeEach
+    public void setUp() {
+        episode = EpisodeFixture.createEpisode();
+        member = MemberFixture.createMember();
+    }
+
+    @Test
+    public void should_ReturnComments_When_EpisodeHasComments() {
+        // Given
+        Comment comment = CommentFixture.createComment(episode, member);
+        when(commentRepository.findCommentsByEpisodeId(episode.getId())).thenReturn(List.of(comment));
+
+        // When
+        EpisodeCommentsDTO result = episodeCommentService.getCommentsByEpisodeId(episode.getId());
+
+        // Then
+        assertEquals(1, result.comments().size());
+        assertEquals(comment.getContent(), result.comments().get(0).content());
+        verify(commentRepository, times(1)).findCommentsByEpisodeId(episode.getId());
+    }
+
+    @Test
+    public void should_CreateComment_When_EpisodeExists() {
+        // Given
+        EpisodeCommentRequestDTO request = new EpisodeCommentRequestDTO("New comment");
+        Comment comment = CommentFixture.createComment(episode, member);
+        when(episodeRepository.findById(any(String.class))).thenReturn(Optional.of(episode));
+        when(memberService.findById(any(String.class))).thenReturn(member);
+        when(commentRepository.save(any(Comment.class))).thenReturn(comment);
+
+        // When
+        CommentDTO result = episodeCommentService.createComment(episode.getId(), member.getId(), request);
+
+        // Then
+        assertEquals(request.content(), result.content());
+        verify(commentRepository, times(1)).save(any(Comment.class));
+    }
+
+    @Test
+    public void should_ThrowException_When_EpisodeNotFoundOnCreate() {
+        // Given
+        when(episodeRepository.findById(any(String.class))).thenReturn(Optional.empty());
+        EpisodeCommentRequestDTO request = new EpisodeCommentRequestDTO("New comment");
+
+        // When & Then
+        EpisodeException exception = assertThrows(EpisodeException.class,
+            () -> episodeCommentService.createComment("invalid-episode-id", member.getId(), request));
+
+        assertEquals(EpisodeErrorCode.EPISODE_NOT_FOUND, exception.getErrorCode());
+        verify(commentRepository, never()).save(any(Comment.class));
+    }
+
+    @Test
+    public void should_DeleteComment_When_CommentExists() {
+        // Given
+        Comment comment = CommentFixture.createComment(episode, member);
+        when(commentRepository.findByIdAndDeletedAtIsNull(comment.getId())).thenReturn(Optional.of(comment));
+
+        // When
+        assertDoesNotThrow(() -> episodeCommentService.deleteComment(comment.getId()));
+
+        // Then
+        verify(commentRepository, times(1)).delete(comment);
+    }
+
+    @Test
+    public void should_ThrowException_When_CommentNotFoundOnDelete() {
+        // Given
+        when(commentRepository.findByIdAndDeletedAtIsNull(any(String.class))).thenReturn(Optional.empty());
+
+        // When & Then
+        EpisodeException exception = assertThrows(EpisodeException.class,
+            () -> episodeCommentService.deleteComment("invalid-comment-id"));
+
+        assertEquals(EpisodeErrorCode.COMMENT_NOT_FOUND, exception.getErrorCode());
+        verify(commentRepository, never()).delete(any(Comment.class));
+    }
+}


### PR DESCRIPTION
## 설명
<!-- PR에서 해결하려는 문제나 기능을 간단히 설명합니다. -->

- 이 PR은 다음의 3가지 기능을 구현합니다.
- 특정 에피소드의 댓글 리스트를 조회하는 API
- 특정 에피소드에 댓글을 생성하는 API
- 댓글을 삭제하는 API


## 포함된 변경 사항
<!-- 코드에서 어떤 변화가 이루어졌는지 요약합니다. 주요 변경 사항을 나열하세요. -->

- 댓글 관련 API를 처리하는 컨트롤러와 서비스를 구현했습니다. `EpisodeCommentController`, `EpisdoeCommentService`
- `CommentRepository`에 에피소드 ID를 기반으로 모든 댓글을 가져오는 JPQL, 댓글 ID를 기반으로 댓글을 조회하는 JPA 쿼리 메서드를 추가했습니다.
- 댓글 Fixture와 서비스 기능에 대한 테스트 코드를 작성했습니다.

## 테스트 방법
<!-- 변경된 부분을 테스트한 방법을 설명합니다. -->

- EpisodeCommentServiceTest를 통해 다음의 5가지 경우를 테스트합니다.
- 에피소드에 댓글이 있을 때, 성공적으로 댓글 목록을 반환
- 에피소드가 존재할 때, 댓글을 성공적으로 생성
- 존재하지 않는 에피소드에 댓글을 생성하려고 하면 예외 발생
- 댓글이 존재할 때, 해당 댓글을 성공적으로 삭제
- 존재하지 않는 댓글을 삭제하려고 하면 예외 발생


## 추가 참고 사항
<!-- 리뷰어가 알아야 할 추가적인 정보나 참고해야 할 내용이 있다면 여기에 작성하세요. 예를 들어, 관련된 이슈 번호나 외부 링크 등을 포함할 수 있습니다. -->

- 이전에 @rkdalsdl98와 상의하여 댓글 리스트는 페이지네이션을 적용하지 않기로 결정했습니다. 이 부분은 추후 변경될 수 있습니다.

## 리뷰 요청 사항
<!-- 리뷰어가 특별히 검토해주었으면 하는 부분이 있다면 여기에 작성합니다. -->

- 댓글 삭제 API의 엔드포인트를 `/api/episodes/{episodeId}/comments/{commentId}`로 작성했습니다. 하지만 실제 로직에서는 에피소드 ID가 사용되지 않습니다.
조회 및 생성 API와의 통일성을 고려해 경로 변수에 에피소드 ID를 추가했는데, 이에 대한 리뷰어님의 의견이 궁금합니다.

