### PR TITLE
hotfix: 댓글 신고 기능 구현

### DIFF
--- a/src/main/java/com/ktb/eatbookappbackend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/comment/repository/CommentRepository.java
@@ -5,8 +5,10 @@ import com.ktb.eatbookappbackend.entity.Comment;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface CommentRepository extends JpaRepository<Comment, String>, CommentRepositoryCustom {
 
@@ -14,4 +16,9 @@ public interface CommentRepository extends JpaRepository<Comment, String>, Comme
 
     @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.id = :commentId AND c.deletedAt IS NULL")
     Optional<Comment> findByIdAndDeletedAtIsNull(@Param("commentId") String commentId);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Comment c SET c.reportCount = c.reportCount + 1 WHERE c.id = :commentId")
+    void incrementReportCount(@Param("commentId") String commentId);
 }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
@@ -13,6 +13,7 @@ import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -72,5 +73,20 @@ public class EpisodeCommentController {
     ) {
         episodeCommentService.deleteComment(commentId, memberId);
         return SuccessResponse.toResponseEntity(EpisodeSuccessCode.COMMENT_DELETED);
+    }
+
+    /**
+     * 댓글을 신고합니다.
+     *
+     * @param commentId 신고할 댓글의 ID
+     * @return 신고 처리된 댓글에 대한 응답
+     */
+    @Secured(Role.MEMBER_VALUE)
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<SuccessResponseDTO> reportComment(
+        @PathVariable("commentId") String commentId
+    ) {
+        episodeCommentService.reportComment(commentId);
+        return SuccessResponse.toResponseEntity(EpisodeSuccessCode.COMMENT_REPORTED);
     }
 }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/message/EpisodeSuccessCode.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/message/EpisodeSuccessCode.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum EpisodeSuccessCode implements MessageCode {
     COMMENTS_RETRIEVED("에피소드의 댓글 리스트를 성공적으로 조회했습니다.", HttpStatus.OK),
     COMMENT_CREATED("성공적으로 댓글을 생성했습니다.", HttpStatus.CREATED),
-    COMMENT_DELETED("성공적으로 댓글을 삭제했습니다.", HttpStatus.OK);
+    COMMENT_DELETED("성공적으로 댓글을 삭제했습니다.", HttpStatus.OK),
+    COMMENT_REPORTED("성공적으로 댓글을 신고했습니다.", HttpStatus.OK);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/service/EpisodeCommentService.java
@@ -84,4 +84,21 @@ public class EpisodeCommentService {
 
         comment.delete();
     }
+
+    /**
+     * 댓글의 신고 횟수를 증가시킵니다.
+     *
+     * @param commentId
+     */
+    @Transactional
+    public void reportComment(String commentId) {
+        commentRepository.incrementReportCount(commentId);
+
+        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+            .orElseThrow(() -> new EpisodeException(EpisodeErrorCode.COMMENT_NOT_FOUND));
+
+        if (comment.getReportCount() >= 5) {
+            comment.delete();
+        }
+    }
 }

--- a/src/main/java/com/ktb/eatbookappbackend/entity/Comment.java
+++ b/src/main/java/com/ktb/eatbookappbackend/entity/Comment.java
@@ -29,6 +29,10 @@ public class Comment extends SoftDeletableEntity {
     @Column(nullable = false, length = 300)
     private String content;
 
+    @NotNull
+    @Column(nullable = false)
+    private int reportCount;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;


### PR DESCRIPTION
## 설명
<!-- PR에서 해결하려는 문제나 기능을 간단히 설명합니다. -->

- 앱 스토어 재심사를 위해 댓글 신고 기능을 구현했습니다. 신고 누적 횟수가 5회 이상인 댓글은 soft-delete 처리됩니다.