### PR TITLE
test: 회원 차단 기능, 댓글 신고 기능에 대한 테스트 코드 및 Javadoc 작성

### DIFF
--- a/src/main/java/com/ktb/eatbookappbackend/domain/block/controller/BlockController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/block/controller/BlockController.java
@@ -23,9 +23,17 @@ public class BlockController {
 
     private final BlockService blockService;
 
+    /**
+     * 현재 멤버를 대상으로 다른 멤버를 차단합니다.
+     *
+     * @param memberId 차단할 멤버를 식별하는 현재 멤버의 ID. 이 ID는 인증 주체로부터 얻습니다.
+     * @param id       차단할 멤버를 식별하는 ID. 이 ID는 요청 매개변수로부터 얻습니다.
+     * @return 차단 작업 결과를 포함하는 ResponseEntity. SuccessResponseDTO에는 차단 작업 결과를 나타내는 성공 코드 (BlockSuccessCode.BLOCK_SUCCESS)와 null 페이로드가 포함됩니다.
+     * @throws IllegalArgumentException memberId 또는 id가 null이거나 비어 있는 경우.
+     */
     @Secured(Role.MEMBER_VALUE)
     @PostMapping()
-    public ResponseEntity<SuccessResponseDTO> blockUser(
+    public ResponseEntity<SuccessResponseDTO> blockMember(
         @AuthenticationPrincipal String memberId,
         @RequestParam(name = "id") String id
     ) {
@@ -33,10 +41,17 @@ public class BlockController {
         return SuccessResponse.toResponseEntity(BlockSuccessCode.BLOCK_SUCCESS, null);
     }
 
+    /**
+     * 차단된 멤버 ID 목록을 가져옵니다.
+     *
+     * @param memberId 차단된 멤버 ID 목록을 가져올 멤버를 식별하는 ID. 이 ID는 인증 주체로부터 얻습니다.
+     * @return 차단된 멤버 ID 목록을 포함하는 ResponseEntity. SuccessResponseDTO에는 차단된 멤버 ID 목록을 나타내는 성공 코드
+     * (BlockSuccessCode.BLOCKED_MEMBER_IDS_RETRIEVED)와 차단된 멤버 ID 목록이 포함됩니다.
+     */
     @Secured(Role.MEMBER_VALUE)
     @GetMapping("/blocked-member-ids")
-    public ResponseEntity<SuccessResponseDTO> getBlockedUsers(@AuthenticationPrincipal String memberId) {
-        BlockedMemberIdsDTO blockedMemberIds = blockService.getBlockedUserIds(memberId);
+    public ResponseEntity<SuccessResponseDTO> getBlockedMembers(@AuthenticationPrincipal String memberId) {
+        BlockedMemberIdsDTO blockedMemberIds = blockService.getBlockedMemberIds(memberId);
         return SuccessResponse.toResponseEntity(BlockSuccessCode.BLOCKED_MEMBER_IDS_RETRIEVED, blockedMemberIds);
     }
 }

--- a/src/main/java/com/ktb/eatbookappbackend/domain/block/service/BlockService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/block/service/BlockService.java
@@ -21,6 +21,14 @@ public class BlockService {
     private final BlockRepository blockRepository;
     private final MemberRepository memberRepository;
 
+    /**
+     * 멤버를 차단합니다.
+     *
+     * @param blockerId 차단을 시작하는 멤버의 ID
+     * @param blockedId 차단되는 멤버의 ID
+     * @throws BlockException  차단자와 차단된 ID가 동일한 경우, 또는 차단이 이미 존재하는 경우에 발생
+     * @throws MemberException 차단자 또는 차단된 멤버가 존재하지 않는 경우에 발생
+     */
     @Transactional
     public void blockMember(String blockerId, String blockedId) {
         if (blockedId.equals(blockerId)) {
@@ -43,8 +51,15 @@ public class BlockService {
         blockRepository.save(block);
     }
 
+    /**
+     * 차단된 멤버 ID 목록을 검색합니다.
+     *
+     * @param memberId 차단된 멤버 ID 목록을 검색할 멤버의 ID
+     * @return 차단된 멤버 ID 목록을 포함하는 {@link BlockedMemberIdsDTO} 객체
+     * @throws MemberException 지정된 멤버 ID가 존재하지 않는 경우
+     */
     @Transactional(readOnly = true)
-    public BlockedMemberIdsDTO getBlockedUserIds(String memberId) {
+    public BlockedMemberIdsDTO getBlockedMemberIds(String memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/controller/EpisodeCommentController.java
@@ -78,8 +78,8 @@ public class EpisodeCommentController {
     /**
      * 댓글을 신고합니다.
      *
-     * @param commentId 신고할 댓글의 ID
-     * @return 신고 처리된 댓글에 대한 응답
+     * @param commentId 신고할 댓글의 고유 식별자.
+     * @return ResponseEntity로, SuccessResponseDTO를 포함하는 응답. 이 응답에는 성공 상태 코드가 포함되어 댓글이 신고되었음을 나타냅니다.
      */
     @Secured(Role.MEMBER_VALUE)
     @PatchMapping("/comments/{commentId}")

--- a/src/main/java/com/ktb/eatbookappbackend/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/ktb/eatbookappbackend/domain/episode/service/EpisodeCommentService.java
@@ -86,9 +86,10 @@ public class EpisodeCommentService {
     }
 
     /**
-     * 댓글의 신고 횟수를 증가시킵니다.
+     * 댓글의 신고 횟수를 증가시킵니다. 만약 신고 횟수가 5회 이상이라면 해당 댓글을 삭제합니다.
      *
-     * @param commentId
+     * @param commentId 신고할 댓글의 고유 ID
+     * @throws EpisodeException 지정된 댓글이 존재하지 않는 경우
      */
     @Transactional
     public void reportComment(String commentId) {

--- a/src/test/java/com/ktb/eatbookappbackend/block/service/BlockServiceTest.java
+++ b/src/test/java/com/ktb/eatbookappbackend/block/service/BlockServiceTest.java
@@ -1,0 +1,132 @@
+package com.ktb.eatbookappbackend.block.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ktb.eatbookappbackend.domain.block.dto.BlockedMemberIdsDTO;
+import com.ktb.eatbookappbackend.domain.block.exception.BlockException;
+import com.ktb.eatbookappbackend.domain.block.message.BlockErrorCode;
+import com.ktb.eatbookappbackend.domain.block.repository.BlockRepository;
+import com.ktb.eatbookappbackend.domain.block.service.BlockService;
+import com.ktb.eatbookappbackend.domain.member.exception.MemberException;
+import com.ktb.eatbookappbackend.domain.member.message.MemberErrorCode;
+import com.ktb.eatbookappbackend.domain.member.repository.MemberRepository;
+import com.ktb.eatbookappbackend.entity.Block;
+import com.ktb.eatbookappbackend.entity.Member;
+import com.ktb.eatbookappbackend.member.fixture.MemberFixture;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BlockServiceTest {
+
+    @Mock
+    private BlockRepository blockRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private BlockService blockService;
+
+    private Member blocker;
+    private Member blocked;
+
+    @BeforeEach
+    public void setUp() {
+        blocker = MemberFixture.createMember();
+        blocked = MemberFixture.createMember();
+    }
+
+    @Test
+    public void should_BlockMember_When_ValidMembers() {
+        // Given
+        when(memberRepository.findById(blocker.getId())).thenReturn(Optional.of(blocker));
+        when(memberRepository.findById(blocked.getId())).thenReturn(Optional.of(blocked));
+        when(blockRepository.existsByBlockerAndBlocked(blocker, blocked)).thenReturn(false);
+
+        // When
+        assertDoesNotThrow(() -> blockService.blockMember(blocker.getId(), blocked.getId()));
+
+        // Then
+        verify(blockRepository, times(1)).save(any(Block.class));
+    }
+
+    @Test
+    public void should_ThrowException_When_SelfBlocked() {
+        // When & Then
+        BlockException exception = assertThrows(BlockException.class,
+            () -> blockService.blockMember(blocker.getId(), blocker.getId()));
+
+        assertEquals(BlockErrorCode.SELF_BLOCKED, exception.getErrorCode());
+        verify(blockRepository, never()).save(any(Block.class));
+    }
+
+    @Test
+    public void should_ThrowException_When_MemberNotFound() {
+        // Given
+        when(memberRepository.findById(any(String.class))).thenReturn(Optional.empty());
+
+        // When & Then
+        MemberException exception = assertThrows(MemberException.class,
+            () -> blockService.blockMember("invalid-blocker-id", blocked.getId()));
+
+        assertEquals(MemberErrorCode.MEMBER_NOT_FOUND, exception.getErrorCode());
+        verify(blockRepository, never()).save(any(Block.class));
+    }
+
+    @Test
+    public void should_ThrowException_When_AlreadyBlocked() {
+        // Given
+        when(memberRepository.findById(blocker.getId())).thenReturn(Optional.of(blocker));
+        when(memberRepository.findById(blocked.getId())).thenReturn(Optional.of(blocked));
+        when(blockRepository.existsByBlockerAndBlocked(blocker, blocked)).thenReturn(true);
+
+        // When & Then
+        BlockException exception = assertThrows(BlockException.class,
+            () -> blockService.blockMember(blocker.getId(), blocked.getId()));
+
+        assertEquals(BlockErrorCode.ALREADY_BLOCKED, exception.getErrorCode());
+        verify(blockRepository, never()).save(any(Block.class));
+    }
+
+    @Test
+    public void should_ReturnBlockedMemberIds_When_MembersBlocked() {
+        // Given
+        Block block = Block.builder().blocker(blocker).blocked(blocked).build();
+        when(memberRepository.findById(blocker.getId())).thenReturn(Optional.of(blocker));
+        when(blockRepository.findByBlocker(blocker)).thenReturn(List.of(block));
+
+        // When
+        BlockedMemberIdsDTO result = blockService.getBlockedMemberIds(blocker.getId());
+
+        // Then
+        assertEquals(1, result.blockedMemberIds().size());
+        assertEquals(blocked.getId(), result.blockedMemberIds().get(0));
+    }
+
+    @Test
+    public void should_ThrowException_When_BlockerNotFound() {
+        // Given
+        when(memberRepository.findById(any(String.class))).thenReturn(Optional.empty());
+
+        // When & Then
+        MemberException exception = assertThrows(MemberException.class,
+            () -> blockService.getBlockedMemberIds("invalid-blocker-id"));
+
+        assertEquals(MemberErrorCode.MEMBER_NOT_FOUND, exception.getErrorCode());
+        verify(blockRepository, never()).findByBlocker(any(Member.class));
+    }
+}


### PR DESCRIPTION
## 설명
<!-- PR에서 해결하려는 문제나 기능을 간단히 설명합니다. -->

- 앱 재심사를 위해 hotfix로 추가한 회원 차단, 댓글 신고 기능에 대해 테스트 코드와 Javadoc을 작성했습니다.
- 회원을 가르키는 네이밍을 `member`로 통일했습니다. 

## 테스트 방법
<!-- 변경된 부분을 테스트한 방법을 설명합니다. -->

- `BlockServiceTest` 테스트 클래스를 생성했습니다. 이 클래스는 아래의 6가지 경우를 검증합니다.
  - 유효한 멤버 간 차단이 정상적으로 이루어지는 경우
  - 자신을 차단하려고 시도하는 경우 예외 발생
  - 차단자 또는 차단 대상 멤버가 존재하지 않지 않는 경우 예외 발생
  - 이미 차단된 상태에서 다시 차단하려는 경우 예외 발생
  - 특정 멤버가 차단한 멤버 ID 목록이 올바르게 반환되는 경우
  - 차단된 멤버 목록 조회를 요청한 차단자가 존재하지 않는 경우 예외 발생
- 기존의 `EpisodeCommentServiceTest`테스트 클래스에 댓글 신고 기능에 대한 테스트 케이스 3개를 추가했습니다.
  - 유효한 댓글이 존재하여 정상적으로 신고 횟수가 증가하는 경우
  - 신고 횟수가 임계치를 초과하여 댓글이 삭제되는 경우
  - 신고하려는 댓글이 존재하지 않는 경우 예외 발생
